### PR TITLE
[FARM]Allow user to click Clam image to show details

### DIFF
--- a/src/views/farms/FarmItem.js
+++ b/src/views/farms/FarmItem.js
@@ -209,7 +209,9 @@ const FarmItem = ({
     <div className="FarmItem">
       <div className="w-1/4 m-2 mx-auto text-center px-4 py-2 badge badge-success">#{clamId}</div>
       <div className="flex-1 justify-center md:flex items-center p-4">
-        <img className="w-auto" src={img} />
+        <button onClick={(e) => onViewDetails(e, clam)}>
+          <img className="w-auto" src={img} />
+        </button>
       </div>
       {clam.processing ? (
         <>


### PR DESCRIPTION
If you click on the clam image in the farm you will see a modal with information about the clam. It is the same as you click on "View Details" button in a deposited clam.